### PR TITLE
Add TCN forecasting and oversampling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,13 +184,24 @@ Commands use the syntax `OPERATION argument`. Operation names are case-insensiti
 | `MatchEnds` | `MatchEnds` | Alias of `Seamless` |
 | `Pad` | `Pad 5m` · `Pad 5m, 0` | Extend by a duration, holding the last value (or a given level) |
 | `HoldLast` | `HoldLast 5m` | Alias of `Pad` |
+| `PadPoints` | `PadPoints 100` · `PadPoints 100, 0` | Append exactly N samples, holding the last value (or a given level) |
+| `HoldLastPoints` | `HoldLastPoints 100` | Alias of `PadPoints` |
 | `ExtendTo` | `ExtendTo 10m` · `ExtendTo 10m, 0` | Extend to an absolute end time, holding the last value (or a given level) |
 | `ExtractPeriod` | `ExtractPeriod` · `ExtractPeriod 0.5` | Keep one cycle from the first rising crossing (auto or given threshold); shift to t=0 |
 | `CutBefore` | `CutBefore 5m` | Discard samples before the timestamp and shift the first retained sample to t=0 |
 | `CutAfter` | `CutAfter 10u` | Discard samples at or after the timestamp |
+| `DropLast` | `DropLast 10u` | Remove samples inside the final duration; retain a sample exactly on the start boundary |
+| `DropLastPoints` | `DropLastPoints 10` | Remove exactly the final N sample points |
 | `Trim` | `Trim 1m, 10m` | Keep samples with start ≤ t < end and shift the first retained sample to t=0 |
 | `Repeat` | `Repeat 2.5` | Append copies of the capture⁴ |
+| `Oversample` | `Oversample 5` | Divide the capture into 5 equal segments and average their aligned samples |
 | `Forecast` | `Forecast 5m` · `Forecast 5m, 500` | Automatically choose a forecast model and append a duration, optionally using an exact number of samples |
+
+`Oversample N` performs coherent ensemble averaging for a repeating capture. The sample count
+must be exactly divisible by N. It returns one segment starting at t=0, preserves the original
+sample interval, and averages each output value from the N corresponding segment values. If the
+division is not exact, the error reports how many samples—and how much capture time—to add or
+remove. Segment alignment is essential: drift or a non-repeating signal will blur the result.
 
 `Forecast duration[, samples]` is a self-contained forecast: it trains on the current waveform and appends
 uniformly spaced future samples, so no model file or extra dependency is needed. It automatically
@@ -198,8 +209,9 @@ backtests causal temporal convolution, repeating-pattern, linear-trend, stable-m
 strategies on a known part of the capture. The best strategy is retrained on the complete capture;
 the console reports its name and a 0–100% backtest confidence. Confidence below 20% also emits a
 warning and uses a conservative competitive forecast. It works best when the capture contains
-several examples of the pattern to predict. The input must contain at
-least 8 finite, uniformly spaced samples; add `ResampleF` before `Forecast` when necessary. Long,
+several examples of the pattern to predict. The input must contain at least 8 finite samples.
+Forecast aligns data by sample position and uses the average interval between the first and last
+timestamps for its output, so small or deliberate timestamp irregularities are accepted. Long,
 chaotic, or changing signals remain inherently uncertain, so treat the result as an estimate.
 
 ### Resampling

--- a/README.md
+++ b/README.md
@@ -186,10 +186,21 @@ Commands use the syntax `OPERATION argument`. Operation names are case-insensiti
 | `HoldLast` | `HoldLast 5m` | Alias of `Pad` |
 | `ExtendTo` | `ExtendTo 10m` · `ExtendTo 10m, 0` | Extend to an absolute end time, holding the last value (or a given level) |
 | `ExtractPeriod` | `ExtractPeriod` · `ExtractPeriod 0.5` | Keep one cycle from the first rising crossing (auto or given threshold); shift to t=0 |
-| `CutBefore` | `CutBefore 5m` | Discard samples before the timestamp |
+| `CutBefore` | `CutBefore 5m` | Discard samples before the timestamp and shift the first retained sample to t=0 |
 | `CutAfter` | `CutAfter 10u` | Discard samples at or after the timestamp |
-| `Trim` | `Trim 1m, 10m` | Keep samples with start ≤ t < end |
+| `Trim` | `Trim 1m, 10m` | Keep samples with start ≤ t < end and shift the first retained sample to t=0 |
 | `Repeat` | `Repeat 2.5` | Append copies of the capture⁴ |
+| `Forecast` | `Forecast 5m` · `Forecast 5m, 500` | Automatically choose a forecast model and append a duration, optionally using an exact number of samples |
+
+`Forecast duration[, samples]` is a self-contained forecast: it trains on the current waveform and appends
+uniformly spaced future samples, so no model file or extra dependency is needed. It automatically
+backtests causal temporal convolution, repeating-pattern, linear-trend, stable-mean, and hold-last
+strategies on a known part of the capture. The best strategy is retrained on the complete capture;
+the console reports its name and a 0–100% backtest confidence. Confidence below 20% also emits a
+warning and uses a conservative competitive forecast. It works best when the capture contains
+several examples of the pattern to predict. The input must contain at
+least 8 finite, uniformly spaced samples; add `ResampleF` before `Forecast` when necessary. Long,
+chaotic, or changing signals remain inherently uncertain, so treat the result as an estimate.
 
 ### Resampling
 

--- a/Sources/rigol2spice/application.swift
+++ b/Sources/rigol2spice/application.swift
@@ -520,6 +520,17 @@ struct Rigol2SpiceApplication {
                     "Padding signal by \(engineeringFormatter.string(duration))s (hold last value)...",
                 )
             }
+        case let .padPoints(count, value):
+            if let value {
+                Console.section(
+                    "Padding signal by \(count) sample points at \(engineeringFormatter.string(value))...",
+                )
+            }
+            else {
+                Console.section(
+                    "Padding signal by \(count) sample points (hold last value)...",
+                )
+            }
         case let .extendTo(endTime, value):
             if let value {
                 Console.section(
@@ -565,12 +576,22 @@ struct Rigol2SpiceApplication {
             Console.section(
                 "Cutting signal before \(engineeringFormatter.string(value))s and shifting it to t=0...",
             )
+        case let .dropLast(duration):
+            Console.section(
+                "Removing the final \(engineeringFormatter.string(duration))s of the signal...",
+            )
+        case let .dropLastPoints(count):
+            Console.section("Removing the final \(count) sample points...")
         case let .trim(start, end):
             Console.section(
                 "Trimming signal from \(engineeringFormatter.string(start))s to \(engineeringFormatter.string(end))s and shifting it to t=0...",
             )
         case let .repeat(amount):
             Console.section("Repeating capture for \(engineeringFormatter.string(amount)) times...")
+        case let .oversample(factor):
+            Console.section(
+                "Averaging \(factor) equal capture segments to improve amplitude resolution...",
+            )
         case let .tcn(duration, sampleCount):
             if let sampleCount {
                 Console.section(

--- a/Sources/rigol2spice/application.swift
+++ b/Sources/rigol2spice/application.swift
@@ -315,6 +315,23 @@ struct Rigol2SpiceApplication {
                 reportFilter(design, transformation: transformation, points: points)
                 points = applyZeroPhaseFilter(design, to: points)
             }
+            else if case let .tcn(duration, sampleCount) = transformation {
+                reportTransformation(transformation, points: points)
+                let result = try tcnForecast(
+                    points,
+                    duration: duration,
+                    sampleCount: sampleCount,
+                    sampleInterval: currentSampleInterval,
+                )
+                Console.detail("Automatic model: \(result.method.displayName)")
+                Console.detail("Backtest confidence: \(Int((result.confidence * 100).rounded()))%")
+                if result.confidence < 0.2 {
+                    Console.warning(
+                        "The capture has little repeatable information about its future. Forecast selected a conservative model; treat it as low confidence.",
+                    )
+                }
+                points = result.points
+            }
             else {
                 reportTransformation(transformation, points: points)
                 points = try transformation.applying(to: points, sampleInterval: currentSampleInterval)
@@ -545,13 +562,26 @@ struct Rigol2SpiceApplication {
         case let .cutAfter(value):
             Console.section("Cutting signal after \(engineeringFormatter.string(value))s...")
         case let .cutBefore(value):
-            Console.section("Cutting signal before \(engineeringFormatter.string(value))s...")
+            Console.section(
+                "Cutting signal before \(engineeringFormatter.string(value))s and shifting it to t=0...",
+            )
         case let .trim(start, end):
             Console.section(
-                "Trimming signal from \(engineeringFormatter.string(start))s to \(engineeringFormatter.string(end))s...",
+                "Trimming signal from \(engineeringFormatter.string(start))s to \(engineeringFormatter.string(end))s and shifting it to t=0...",
             )
         case let .repeat(amount):
             Console.section("Repeating capture for \(engineeringFormatter.string(amount)) times...")
+        case let .tcn(duration, sampleCount):
+            if let sampleCount {
+                Console.section(
+                    "Forecasting \(engineeringFormatter.string(duration))s as \(sampleCount) samples automatically...",
+                )
+            }
+            else {
+                Console.section(
+                    "Forecasting \(engineeringFormatter.string(duration))s automatically...",
+                )
+            }
         case let .am(carrier, depth, amplitude):
             Console.section(
                 "AM-modulating at \(engineeringFormatter.string(carrier))Hz (depth \(engineeringFormatter.string(depth)), carrier amplitude \(engineeringFormatter.string(amplitude)))...",

--- a/Sources/rigol2spice/oversample.swift
+++ b/Sources/rigol2spice/oversample.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+// MARK: - OversampleError
+
+enum OversampleError: LocalizedError, Equatable {
+    case factorExceedsPointCount(factor: Int, pointCount: Int)
+    case pointCountNotDivisible(
+        factor: Int,
+        pointCount: Int,
+        removePoints: Int,
+        addPoints: Int,
+        sampleInterval: Double,
+    )
+    case nonFiniteSample(index: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case let .factorExceedsPointCount(factor, pointCount):
+            "Oversample factor \(factor) exceeds the capture's \(pointCount) samples"
+        case let .pointCountNotDivisible(
+            factor,
+            pointCount,
+            removePoints,
+            addPoints,
+            sampleInterval,
+        ):
+            "Oversample \(factor) requires a sample count divisible by \(factor), but the capture has \(pointCount) samples. Remove \(removePoints) sample(s) (\(engineeringFormatter.string(Double(removePoints) * sampleInterval))s) or add \(addPoints) sample(s) (\(engineeringFormatter.string(Double(addPoints) * sampleInterval))s)."
+        case let .nonFiniteSample(index):
+            "Oversample requires finite timestamps and values; sample \(index) is not finite"
+        }
+    }
+}
+
+/// Divide a capture into `factor` equal contiguous segments and average aligned values.
+/// This is coherent ensemble averaging: it improves repeatable-signal amplitude resolution
+/// while retaining the source sampling interval and one segment's duration.
+func oversamplePoints(
+    _ points: [Point],
+    factor: Int,
+    sampleInterval providedSampleInterval: Double? = nil,
+) throws -> [Point] {
+    guard factor > 1 else {
+        throw TransformationParseError.invalidResamplingFactor(
+            operation: "Oversample",
+            value: String(factor),
+        )
+    }
+    guard factor <= points.count else {
+        throw OversampleError.factorExceedsPointCount(factor: factor, pointCount: points.count)
+    }
+
+    for (index, point) in points.enumerated() where !point.time.isFinite || !point.value.isFinite {
+        throw OversampleError.nonFiniteSample(index: index)
+    }
+
+    let measuredInterval = (points[points.count - 1].time - points[0].time)
+        / Double(points.count - 1)
+    let gridInterval = if measuredInterval.isFinite, measuredInterval > 0 {
+        measuredInterval
+    }
+    else {
+        try resolveSampleInterval(
+            providedSampleInterval,
+            points: points,
+            operation: "Oversample",
+        )
+    }
+    let timestampMagnitude = max(1, abs(points[0].time), abs(points[points.count - 1].time))
+    let intervalTolerance = max(
+        abs(gridInterval) * 1e-6,
+        timestampMagnitude * Double.ulpOfOne * 16,
+        1e-15,
+    )
+    let sampleInterval = if let providedSampleInterval,
+                            providedSampleInterval.isFinite,
+                            providedSampleInterval > 0,
+                            abs(providedSampleInterval - gridInterval) <= intervalTolerance {
+        providedSampleInterval
+    }
+    else {
+        gridInterval
+    }
+
+    let remainder = points.count % factor
+    guard remainder == 0 else {
+        throw OversampleError.pointCountNotDivisible(
+            factor: factor,
+            pointCount: points.count,
+            removePoints: remainder,
+            addPoints: factor - remainder,
+            sampleInterval: sampleInterval,
+        )
+    }
+
+    let segmentPointCount = points.count / factor
+    var output: [Point] = []
+    output.reserveCapacity(segmentPointCount)
+    for pointIndex in 0 ..< segmentPointCount {
+        var sum = 0.0
+        var compensation = 0.0
+        for segmentIndex in 0 ..< factor {
+            let value = points[segmentIndex * segmentPointCount + pointIndex].value
+            let corrected = value - compensation
+            let updated = sum + corrected
+            compensation = (updated - sum) - corrected
+            sum = updated
+        }
+        output.append(Point(
+            time: Double(pointIndex) * sampleInterval,
+            value: sum / Double(factor),
+        ))
+    }
+    return output
+}

--- a/Sources/rigol2spice/tcnForecast.swift
+++ b/Sources/rigol2spice/tcnForecast.swift
@@ -5,7 +5,6 @@ import Foundation
 enum TCNForecastError: LocalizedError, Equatable {
     case notEnoughSamples(actual: Int, minimum: Int)
     case nonFiniteSample(index: Int)
-    case nonUniformSampling(index: Int)
     case pointCountTooLarge(duration: Double)
 
     var errorDescription: String? {
@@ -14,8 +13,6 @@ enum TCNForecastError: LocalizedError, Equatable {
             "Forecast requires at least \(minimum) samples, but received \(actual)"
         case let .nonFiniteSample(index):
             "Forecast requires finite timestamps and values; sample \(index) is not finite"
-        case let .nonUniformSampling(index):
-            "Forecast requires uniformly spaced samples; sample \(index) is off the sampling grid. Add ResampleF before Forecast"
         case let .pointCountTooLarge(duration):
             "Forecast duration \(duration) would create too many samples"
         }
@@ -89,12 +86,18 @@ func tcnForecast(
         throw TCNForecastError.nonFiniteSample(index: index)
     }
 
-    let sampleInterval = try resolveSampleInterval(
-        providedSampleInterval,
-        points: points,
-        operation: "Forecast",
-    )
-    try validateTCNSampling(points, sampleInterval: sampleInterval)
+    let measuredInterval = (points[points.count - 1].time - points[0].time)
+        / Double(points.count - 1)
+    let sampleInterval = if measuredInterval.isFinite, measuredInterval > 0 {
+        measuredInterval
+    }
+    else {
+        try resolveSampleInterval(
+            providedSampleInterval,
+            points: points,
+            operation: "Forecast",
+        )
+    }
 
     let forecastRatio = duration / sampleInterval
     let nearestForecastCount = forecastRatio.rounded()
@@ -319,17 +322,6 @@ private func fittedTCNTrend(_ values: [Double]) -> TCNTrend {
         return TCNTrend(intercept: mean, slope: 0)
     }
     return TCNTrend(intercept: intercept, slope: slope)
-}
-
-private func validateTCNSampling(_ points: [Point], sampleInterval: Double) throws {
-    let origin = points[0].time
-    let tolerance = max(abs(sampleInterval) * 1e-6, 1e-15)
-    for index in 1 ..< points.count {
-        let expected = origin + Double(index) * sampleInterval
-        if abs(points[index].time - expected) > tolerance * max(1, Double(index)) {
-            throw TCNForecastError.nonUniformSampling(index: index)
-        }
-    }
 }
 
 /// Build a sparse dilated causal kernel: dense recent taps plus an automatically detected

--- a/Sources/rigol2spice/tcnForecast.swift
+++ b/Sources/rigol2spice/tcnForecast.swift
@@ -1,0 +1,506 @@
+import Foundation
+
+// MARK: - TCNForecastError
+
+enum TCNForecastError: LocalizedError, Equatable {
+    case notEnoughSamples(actual: Int, minimum: Int)
+    case nonFiniteSample(index: Int)
+    case nonUniformSampling(index: Int)
+    case pointCountTooLarge(duration: Double)
+
+    var errorDescription: String? {
+        switch self {
+        case let .notEnoughSamples(actual, minimum):
+            "Forecast requires at least \(minimum) samples, but received \(actual)"
+        case let .nonFiniteSample(index):
+            "Forecast requires finite timestamps and values; sample \(index) is not finite"
+        case let .nonUniformSampling(index):
+            "Forecast requires uniformly spaced samples; sample \(index) is off the sampling grid. Add ResampleF before Forecast"
+        case let .pointCountTooLarge(duration):
+            "Forecast duration \(duration) would create too many samples"
+        }
+    }
+}
+
+private let tcnMinimumSampleCount = 8
+private let tcnMaximumLocalContext = 32
+private let tcnMaximumTrainingRows = 8192
+let tcnMaximumForecastSamples = 10_000_000
+
+// MARK: - TCNForecastMethod
+
+enum TCNForecastMethod: Equatable {
+    case temporalConvolution
+    case seasonal(period: Int)
+    case linearTrend
+    case mean
+    case holdLast
+
+    var displayName: String {
+        switch self {
+        case .temporalConvolution: "causal temporal convolution"
+        case let .seasonal(period): "repeating pattern (\(period)-sample period)"
+        case .linearTrend: "linear trend"
+        case .mean: "stable mean"
+        case .holdLast: "hold last value"
+        }
+    }
+}
+
+// MARK: - TCNForecastResult
+
+struct TCNForecastResult {
+    let points: [Point]
+    let method: TCNForecastMethod
+    /// Validation quality from 0 (unpredictable) to 1 (near-perfect reconstruction).
+    let confidence: Double
+}
+
+/// Append a forecast from a compact, single-channel causal temporal convolutional network.
+///
+/// The network is an autoregressive causal Conv1D layer. Its kernel and bias are fitted to
+/// the tail of the capture with ridge regression, then evaluated recursively. Standardizing
+/// the signal makes the fixed regularization useful across engineering scales.
+func tcnForecastPoints(
+    _ points: [Point],
+    duration: Double,
+    sampleCount requestedSampleCount: Int? = nil,
+    sampleInterval providedSampleInterval: Double? = nil,
+) throws -> [Point] {
+    try tcnForecast(
+        points,
+        duration: duration,
+        sampleCount: requestedSampleCount,
+        sampleInterval: providedSampleInterval,
+    ).points
+}
+
+func tcnForecast(
+    _ points: [Point],
+    duration: Double,
+    sampleCount requestedSampleCount: Int? = nil,
+    sampleInterval providedSampleInterval: Double? = nil,
+) throws -> TCNForecastResult {
+    guard points.count >= tcnMinimumSampleCount else {
+        throw TCNForecastError.notEnoughSamples(actual: points.count, minimum: tcnMinimumSampleCount)
+    }
+
+    for (index, point) in points.enumerated() where !point.time.isFinite || !point.value.isFinite {
+        throw TCNForecastError.nonFiniteSample(index: index)
+    }
+
+    let sampleInterval = try resolveSampleInterval(
+        providedSampleInterval,
+        points: points,
+        operation: "Forecast",
+    )
+    try validateTCNSampling(points, sampleInterval: sampleInterval)
+
+    let forecastRatio = duration / sampleInterval
+    let nearestForecastCount = forecastRatio.rounded()
+    let ratioTolerance = max(1, abs(forecastRatio)) * 1e-12
+    let rawForecastCount = abs(forecastRatio - nearestForecastCount) <= ratioTolerance
+        ? nearestForecastCount
+        : ceil(forecastRatio)
+    guard rawForecastCount.isFinite,
+          rawForecastCount > 0,
+          rawForecastCount <= Double(tcnMaximumForecastSamples),
+          rawForecastCount <= Double(Int.max),
+          points.count <= Int.max - Int(rawForecastCount) else {
+        throw TCNForecastError.pointCountTooLarge(duration: duration)
+    }
+    let forecastCount = Int(rawForecastCount)
+    if let requestedSampleCount {
+        guard requestedSampleCount > 0,
+              requestedSampleCount <= tcnMaximumForecastSamples,
+              points.count <= Int.max - requestedSampleCount else {
+            throw TCNForecastError.pointCountTooLarge(duration: duration)
+        }
+    }
+
+    let values = points.map(\.value)
+    let selection = selectTCNForecastMethod(values: values, requestedHorizon: forecastCount)
+    let method = resolvedTCNMethod(selection.method, values: values)
+    let forecast = forecastValues(values, count: forecastCount, method: method)
+    let nativeForecast = appendTCNForecast(
+        to: points,
+        values: forecast,
+        sampleInterval: sampleInterval,
+    )
+    let output = resampleTCNForecastIfNeeded(
+        nativeForecast,
+        originalCount: points.count,
+        duration: duration,
+        sampleCount: requestedSampleCount,
+        sampleInterval: sampleInterval,
+    )
+    return TCNForecastResult(
+        points: output,
+        method: method,
+        confidence: selection.confidence,
+    )
+}
+
+private func selectTCNForecastMethod(
+    values: [Double],
+    requestedHorizon: Int,
+) -> (method: TCNForecastMethod, confidence: Double) {
+    guard values.count >= 24 else {
+        return (.temporalConvolution, 0)
+    }
+    let validationCount = min(max(8, values.count / 5), min(values.count / 3, requestedHorizon))
+    guard validationCount >= 4 else {
+        return (.temporalConvolution, 0)
+    }
+
+    let training = Array(values.dropLast(validationCount))
+    let expected = Array(values.suffix(validationCount))
+    var methods: [TCNForecastMethod] = [.holdLast, .mean, .linearTrend]
+    if let period = detectedTCNPeriod(values: training) {
+        methods.append(.seasonal(period: period))
+    }
+    methods.append(.temporalConvolution)
+
+    var bestMethod = methods[0]
+    var bestError = meanAbsoluteError(
+        forecastValues(training, count: validationCount, method: bestMethod),
+        expected,
+    )
+    for method in methods.dropFirst() {
+        let error = meanAbsoluteError(
+            forecastValues(training, count: validationCount, method: method),
+            expected,
+        )
+        // Prefer the simpler earlier method unless the alternative is materially better.
+        if error < bestError * 0.98 {
+            bestMethod = method
+            bestError = error
+        }
+    }
+
+    let expectedMean = expected.reduce(0, +) / Double(expected.count)
+    let expectedScale = sqrt(expected.reduce(0) { $0 + pow($1 - expectedMean, 2) } / Double(expected.count))
+    var normalizedError = bestError / max(expectedScale, 1e-12)
+    if normalizedError > 0.8, bestMethod != .holdLast, bestMethod != .mean {
+        let holdError = meanAbsoluteError(
+            forecastValues(training, count: validationCount, method: .holdLast),
+            expected,
+        )
+        let meanError = meanAbsoluteError(
+            forecastValues(training, count: validationCount, method: .mean),
+            expected,
+        )
+        if meanError < holdError * 0.98 {
+            bestMethod = .mean
+            bestError = meanError
+        }
+        else {
+            bestMethod = .holdLast
+            bestError = holdError
+        }
+        normalizedError = bestError / max(expectedScale, 1e-12)
+    }
+    return (bestMethod, max(0, min(1, 1 - normalizedError)))
+}
+
+private func forecastValues(_ values: [Double], count: Int, method: TCNForecastMethod) -> [Double] {
+    switch method {
+    case .temporalConvolution:
+        temporalConvolutionForecast(values, count: count)
+    case let .seasonal(period):
+        seasonalForecast(values, count: count, period: period)
+    case .linearTrend:
+        trendForecast(values, count: count)
+    case .mean:
+        Array(repeating: values.reduce(0, +) / Double(values.count), count: count)
+    case .holdLast:
+        Array(repeating: values.last ?? 0, count: count)
+    }
+}
+
+private func temporalConvolutionForecast(_ values: [Double], count: Int) -> [Double] {
+    let trend = fittedTCNTrend(values)
+    let residuals = values.enumerated().map { index, value in value - trend.value(at: index) }
+    let variance = residuals.reduce(0) { $0 + $1 * $1 } / Double(residuals.count)
+    let scale = sqrt(variance)
+    if !scale.isFinite || scale <= max(1, values.map(abs).max() ?? 0) * 1e-12 {
+        return (0 ..< count).map { trend.value(at: values.count + $0) }
+    }
+
+    var normalized = residuals.map { $0 / scale }
+    let lags = tcnCausalLags(values: normalized)
+    let coefficients = fitCausalConvolution(values: normalized, lags: lags)
+    let observedMinimum = normalized.min() ?? -1
+    let observedMaximum = normalized.max() ?? 1
+    let observedRange = max(observedMaximum - observedMinimum, 1)
+    let lowerBound = observedMinimum - 2 * observedRange
+    let upperBound = observedMaximum + 2 * observedRange
+    var output: [Double] = []
+    output.reserveCapacity(count)
+    for offset in 0 ..< count {
+        var prediction = coefficients[0]
+        for (coefficientIndex, lag) in lags.enumerated() {
+            prediction += coefficients[coefficientIndex + 1] * normalized[normalized.count - lag]
+        }
+        prediction = min(upperBound, max(lowerBound, prediction))
+        normalized.append(prediction)
+        output.append(trend.value(at: values.count + offset) + prediction * scale)
+    }
+    return output
+}
+
+private func seasonalForecast(_ values: [Double], count: Int, period: Int) -> [Double] {
+    guard period > 0, period <= values.count else {
+        return Array(repeating: values.last ?? 0, count: count)
+    }
+    var history = values
+    var output: [Double] = []
+    output.reserveCapacity(count)
+    for _ in 0 ..< count {
+        let value = history[history.count - period]
+        history.append(value)
+        output.append(value)
+    }
+    return output
+}
+
+private func trendForecast(_ values: [Double], count: Int) -> [Double] {
+    let trend = fittedTCNTrend(values)
+    return (0 ..< count).map { trend.value(at: values.count + $0) }
+}
+
+private func meanAbsoluteError(_ predicted: [Double], _ expected: [Double]) -> Double {
+    zip(predicted, expected).reduce(0) { $0 + abs($1.0 - $1.1) } / Double(expected.count)
+}
+
+private func resolvedTCNMethod(_ method: TCNForecastMethod, values: [Double]) -> TCNForecastMethod {
+    if case .seasonal = method, let period = detectedTCNPeriod(values: values) {
+        return .seasonal(period: period)
+    }
+    return method
+}
+
+// MARK: - TCNTrend
+
+private struct TCNTrend {
+    let intercept: Double
+    let slope: Double
+
+    func value(at index: Int) -> Double {
+        intercept + slope * Double(index)
+    }
+}
+
+/// Keep a linear trend only when it is materially larger than the temporal residual.
+/// This avoids interpreting a partial cycle of an otherwise stationary waveform as drift.
+private func fittedTCNTrend(_ values: [Double]) -> TCNTrend {
+    if values.min() == values.max() {
+        return TCNTrend(intercept: values[0], slope: 0)
+    }
+    let count = Double(values.count)
+    let center = (count - 1) / 2
+    let mean = values.reduce(0, +) / count
+    var covariance = 0.0
+    var indexVariance = 0.0
+    for (index, value) in values.enumerated() {
+        let centeredIndex = Double(index) - center
+        covariance += centeredIndex * (value - mean)
+        indexVariance += centeredIndex * centeredIndex
+    }
+    let slope = indexVariance > 0 ? covariance / indexVariance : 0
+    let intercept = mean - slope * center
+
+    let residualVariance = values.enumerated().reduce(0.0) { partial, element in
+        let residual = element.element - (intercept + slope * Double(element.offset))
+        return partial + residual * residual
+    } / count
+    let trendSpan = abs(slope) * (count - 1)
+    guard trendSpan > 2 * sqrt(residualVariance) else {
+        return TCNTrend(intercept: mean, slope: 0)
+    }
+    return TCNTrend(intercept: intercept, slope: slope)
+}
+
+private func validateTCNSampling(_ points: [Point], sampleInterval: Double) throws {
+    let origin = points[0].time
+    let tolerance = max(abs(sampleInterval) * 1e-6, 1e-15)
+    for index in 1 ..< points.count {
+        let expected = origin + Double(index) * sampleInterval
+        if abs(points[index].time - expected) > tolerance * max(1, Double(index)) {
+            throw TCNForecastError.nonUniformSampling(index: index)
+        }
+    }
+}
+
+/// Build a sparse dilated causal kernel: dense recent taps plus an automatically detected
+/// seasonal tap. The long tap gives the TCN enough receptive field for oscilloscope captures
+/// whose period is much longer than their local edge shape.
+private func tcnCausalLags(values: [Double]) -> [Int] {
+    let localContext = min(tcnMaximumLocalContext, max(4, (values.count - 1) / 8))
+    var lags = Array(1 ... localContext)
+    guard let bestLag = detectedTCNPeriod(values: values), bestLag > localContext else {
+        return lags
+    }
+    for lag in max(localContext + 1, bestLag - 2) ... min(values.count - 1, bestLag + 2) {
+        lags.append(lag)
+    }
+    return lags
+}
+
+private func detectedTCNPeriod(values: [Double]) -> Int? {
+    let minimumLag = min(tcnMaximumLocalContext, max(4, (values.count - 1) / 8)) + 1
+    let maximumLag = min(values.count * 2 / 3, values.count - 8)
+    guard maximumLag >= minimumLag else {
+        return nil
+    }
+    let variance = values.reduce(0) { $0 + $1 * $1 } / Double(values.count)
+    guard variance > 0 else {
+        return nil
+    }
+    var bestLag: Int?
+    var bestError = Double.infinity
+    for lag in minimumLag ... maximumLag {
+        var squaredError = 0.0
+        for index in lag ..< values.count {
+            let difference = values[index] - values[index - lag]
+            squaredError += difference * difference
+        }
+        let error = squaredError / Double(values.count - lag)
+        if error < bestError {
+            bestError = error
+            bestLag = lag
+        }
+    }
+
+    // Independent samples have expected difference energy of about 2 × variance.
+    // Require a much stronger match before treating a lag as a repeating period.
+    return if let bestLag, bestError < variance * 0.5 { bestLag } else { nil }
+}
+
+private func fitCausalConvolution(values: [Double], lags: [Int]) -> [Double] {
+    let parameterCount = lags.count + 1 // bias plus one weight per causal kernel tap
+    var gram = Array(repeating: Array(repeating: 0.0, count: parameterCount), count: parameterCount)
+    var target = Array(repeating: 0.0, count: parameterCount)
+    let firstRow = max(lags.max() ?? 1, values.count - tcnMaximumTrainingRows)
+
+    for sampleIndex in firstRow ..< values.count {
+        var features = Array(repeating: 1.0, count: parameterCount)
+        for (featureIndex, lag) in lags.enumerated() {
+            features[featureIndex + 1] = values[sampleIndex - lag]
+        }
+        for row in 0 ..< parameterCount {
+            target[row] += features[row] * values[sampleIndex]
+            for column in row ..< parameterCount {
+                gram[row][column] += features[row] * features[column]
+            }
+        }
+    }
+
+    for row in 0 ..< parameterCount {
+        for column in 0 ..< row {
+            gram[row][column] = gram[column][row]
+        }
+    }
+
+    let trainingRowCount = max(1, values.count - firstRow)
+    let regularization = Double(trainingRowCount) * 1e-6
+    for index in 1 ..< parameterCount { // Do not regularize the bias.
+        gram[index][index] += regularization
+    }
+
+    return solveLinearSystem(gram, target) ?? fallbackTCNCoefficients(lags: lags)
+}
+
+private func solveLinearSystem(_ matrix: [[Double]], _ vector: [Double]) -> [Double]? {
+    var a = matrix
+    var b = vector
+    let count = b.count
+
+    for pivot in 0 ..< count {
+        var bestRow = pivot
+        for row in (pivot + 1) ..< count where abs(a[row][pivot]) > abs(a[bestRow][pivot]) {
+            bestRow = row
+        }
+        guard abs(a[bestRow][pivot]) > 1e-14 else {
+            return nil
+        }
+        if bestRow != pivot {
+            a.swapAt(bestRow, pivot)
+            b.swapAt(bestRow, pivot)
+        }
+
+        let divisor = a[pivot][pivot]
+        for column in pivot ..< count {
+            a[pivot][column] /= divisor
+        }
+        b[pivot] /= divisor
+
+        for row in 0 ..< count where row != pivot {
+            let factor = a[row][pivot]
+            guard factor != 0 else {
+                continue
+            }
+            for column in pivot ..< count {
+                a[row][column] -= factor * a[pivot][column]
+            }
+            b[row] -= factor * b[pivot]
+        }
+    }
+
+    return b.allSatisfy(\.isFinite) ? b : nil
+}
+
+private func fallbackTCNCoefficients(lags: [Int]) -> [Double] {
+    var coefficients = Array(repeating: 0.0, count: lags.count + 1)
+    if let lastValueIndex = lags.firstIndex(of: 1) {
+        coefficients[lastValueIndex + 1] = 1 // Hold the last value if fitting becomes singular.
+    }
+    return coefficients
+}
+
+private func appendTCNForecast(
+    to points: [Point],
+    values: [Double],
+    sampleInterval: Double,
+) -> [Point] {
+    var output = points
+    output.reserveCapacity(points.count + values.count)
+    let lastTime = points[points.count - 1].time
+    for (offset, value) in values.enumerated() {
+        output.append(Point(
+            time: lastTime + Double(offset + 1) * sampleInterval,
+            value: value,
+        ))
+    }
+    return output
+}
+
+private func resampleTCNForecastIfNeeded(
+    _ nativeForecast: [Point],
+    originalCount: Int,
+    duration: Double,
+    sampleCount: Int?,
+    sampleInterval: Double,
+) -> [Point] {
+    guard let sampleCount else {
+        return nativeForecast
+    }
+
+    let original = nativeForecast.prefix(originalCount)
+    let lastOriginal = nativeForecast[originalCount - 1]
+    let timelineValues = [lastOriginal.value] + nativeForecast.dropFirst(originalCount).map(\.value)
+    var output = Array(original)
+    output.reserveCapacity(originalCount + sampleCount)
+
+    for outputIndex in 1 ... sampleCount {
+        let elapsed = duration * Double(outputIndex) / Double(sampleCount)
+        let sourcePosition = elapsed / sampleInterval
+        let lowerIndex = min(Int(sourcePosition.rounded(.down)), timelineValues.count - 1)
+        let upperIndex = min(lowerIndex + 1, timelineValues.count - 1)
+        let fraction = sourcePosition - Double(lowerIndex)
+        let value = timelineValues[lowerIndex]
+            + fraction * (timelineValues[upperIndex] - timelineValues[lowerIndex])
+        output.append(Point(time: lastOriginal.time + elapsed, value: value))
+    }
+    return output
+}

--- a/Sources/rigol2spice/transformations.swift
+++ b/Sources/rigol2spice/transformations.swift
@@ -100,6 +100,7 @@ enum Transformation: Equatable {
     case triggerRunt(edge: TriggerEdge, low: Double, high: Double, maximumDuration: Double)
     case seamless(rampDuration: Double?)
     case pad(duration: Double, value: Double?)
+    case padPoints(count: Int, value: Double?)
     case extendTo(endTime: Double, value: Double?)
     case downsample(factor: Double, interpolation: ResamplingInterpolation)
     case upsample(factor: Double, interpolation: ResamplingInterpolation)
@@ -107,8 +108,12 @@ enum Transformation: Equatable {
     case extractPeriod(threshold: Double?)
     case cutAfter(Double)
     case cutBefore(Double)
+    case dropLast(Double)
+    case dropLastPoints(Int)
     case trim(start: Double, end: Double)
     case `repeat`(Double)
+    /// Coherently average aligned points from equal contiguous capture segments.
+    case oversample(Int)
     /// Learn a compact causal temporal convolution from the capture and append a forecast.
     case tcn(duration: Double, sampleCount: Int?)
     case am(carrier: Double, depth: Double, amplitude: Double)
@@ -856,6 +861,23 @@ enum Transformation: Equatable {
                     nil
                 }
                 return .pad(duration: duration, value: holdValue)
+            case "padpoints",
+                 "holdlastpoints":
+                guard arguments.count == 1 || arguments.count == 2 else {
+                    throw TransformationParseError.invalidArgumentCount(
+                        operation: operation,
+                        expected: 1,
+                        actual: arguments.count,
+                    )
+                }
+                let count = try positiveInteger(at: 0)
+                let holdValue: Double? = if arguments.count == 2 {
+                    try parseScalarArgument(arguments[1])
+                }
+                else {
+                    nil
+                }
+                return .padPoints(count: count, value: holdValue)
             case "extendto":
                 guard arguments.count == 1 || arguments.count == 2 else {
                     throw TransformationParseError.invalidArgumentCount(
@@ -931,6 +953,18 @@ enum Transformation: Equatable {
                 return .cutAfter(value)
             case "cutbefore":
                 return try .cutBefore(scalar())
+            case "droplast":
+                let duration = try scalar()
+                guard duration > 0 else {
+                    throw TransformationParseError.invalidPositiveScalar(
+                        operation: operation,
+                        value: arguments[0],
+                    )
+                }
+                return .dropLast(duration)
+            case "droplastpoints":
+                try requireArgumentCount(1)
+                return try .dropLastPoints(positiveInteger(at: 0))
             case "trim":
                 try requireArgumentCount(2)
                 let start = try parseScalarArgument(arguments[0])
@@ -949,6 +983,16 @@ enum Transformation: Equatable {
                     throw TransformationParseError.invalidPositiveScalar(operation: operation, value: arguments[0])
                 }
                 return .repeat(value)
+            case "oversample":
+                try requireArgumentCount(1)
+                let factor = try positiveInteger(at: 0)
+                guard factor > 1 else {
+                    throw TransformationParseError.invalidResamplingFactor(
+                        operation: operation,
+                        value: arguments[0],
+                    )
+                }
+                return .oversample(factor)
             case "forecast":
                 guard arguments.count == 1 || arguments.count == 2 else {
                     throw TransformationParseError.invalidArgumentCount(
@@ -1086,6 +1130,7 @@ enum Transformation: Equatable {
              .triggerRunt,
              .seamless,
              .pad,
+             .padPoints,
              .extendTo,
              .downsample,
              .upsample,
@@ -1093,8 +1138,11 @@ enum Transformation: Equatable {
              .extractPeriod,
              .cutAfter,
              .cutBefore,
+             .dropLast,
+             .dropLastPoints,
              .trim,
              .repeat,
+             .oversample,
              .tcn:
             true
         default:
@@ -1266,7 +1314,14 @@ enum Transformation: Equatable {
         case let .seamless(rampDuration):
             return seamlessPoints(points, rampDuration: rampDuration)
         case let .pad(duration, value):
-            return padPoints(points, duration: duration, value: value)
+            return padDurationPoints(points, duration: duration, value: value)
+        case let .padPoints(count, value):
+            return try padPointCount(
+                points,
+                count: count,
+                value: value,
+                sampleInterval: sampleInterval,
+            )
         case let .extendTo(endTime, value):
             return extendPoints(to: endTime, points: points, value: value)
         case let .downsample(factor, interpolation):
@@ -1295,10 +1350,20 @@ enum Transformation: Equatable {
             return cutPointsAfter(points, after: value)
         case let .cutBefore(value):
             return cutPointsBefore(points, before: value)
+        case let .dropLast(duration):
+            return dropLastDurationPoints(points, duration: duration)
+        case let .dropLastPoints(count):
+            return droppingLastPoints(points, count: count)
         case let .trim(start, end):
             return trimPoints(points, start: start, end: end)
         case let .repeat(amount):
             return try repeatPoints(points, amount: amount)
+        case let .oversample(factor):
+            return try oversamplePoints(
+                points,
+                factor: factor,
+                sampleInterval: sampleInterval,
+            )
         case let .tcn(duration, sampleCount):
             return try tcnForecastPoints(
                 points,

--- a/Sources/rigol2spice/transformations.swift
+++ b/Sources/rigol2spice/transformations.swift
@@ -109,6 +109,8 @@ enum Transformation: Equatable {
     case cutBefore(Double)
     case trim(start: Double, end: Double)
     case `repeat`(Double)
+    /// Learn a compact causal temporal convolution from the capture and append a forecast.
+    case tcn(duration: Double, sampleCount: Int?)
     case am(carrier: Double, depth: Double, amplitude: Double)
     case fm(carrier: Double, sensitivity: Double, amplitude: Double)
     case pm(carrier: Double, sensitivity: Double, amplitude: Double)
@@ -947,6 +949,34 @@ enum Transformation: Equatable {
                     throw TransformationParseError.invalidPositiveScalar(operation: operation, value: arguments[0])
                 }
                 return .repeat(value)
+            case "forecast":
+                guard arguments.count == 1 || arguments.count == 2 else {
+                    throw TransformationParseError.invalidArgumentCount(
+                        operation: operation,
+                        expected: 1,
+                        actual: arguments.count,
+                    )
+                }
+                let duration = try parseScalarArgument(arguments[0])
+                guard duration > 0 else {
+                    throw TransformationParseError.invalidPositiveScalar(
+                        operation: operation,
+                        value: arguments[0],
+                    )
+                }
+                let sampleCount: Int? = if arguments.count == 2 {
+                    try positiveInteger(at: 1)
+                }
+                else {
+                    nil
+                }
+                if let sampleCount, sampleCount > tcnMaximumForecastSamples {
+                    throw TransformationParseError.invalidPositiveScalar(
+                        operation: operation,
+                        value: arguments[1],
+                    )
+                }
+                return .tcn(duration: duration, sampleCount: sampleCount)
             case "am",
                  "modulateam":
                 guard arguments.count == 2 || arguments.count == 3 else {
@@ -1064,7 +1094,8 @@ enum Transformation: Equatable {
              .cutAfter,
              .cutBefore,
              .trim,
-             .repeat:
+             .repeat,
+             .tcn:
             true
         default:
             false
@@ -1268,6 +1299,13 @@ enum Transformation: Equatable {
             return trimPoints(points, start: start, end: end)
         case let .repeat(amount):
             return try repeatPoints(points, amount: amount)
+        case let .tcn(duration, sampleCount):
+            return try tcnForecastPoints(
+                points,
+                duration: duration,
+                sampleCount: sampleCount,
+                sampleInterval: sampleInterval,
+            )
         case let .am(carrier, depth, amplitude):
             return try modulateAMPoints(
                 points,

--- a/Sources/rigol2spice/xTransforms.swift
+++ b/Sources/rigol2spice/xTransforms.swift
@@ -239,7 +239,7 @@ func extractPeriodPoints(_ points: [Point], threshold: Double?) throws -> [Point
 
     let start = crossings[0]
     let end = start + period
-    let trimmed = trimPoints(points, start: start, end: end)
+    let trimmed = pointsInHalfOpenRange(points, start: start, end: end)
     guard trimmed.count >= 2 else {
         throw Rigol2SpiceError.periodNotDetected
     }
@@ -655,21 +655,34 @@ func cutPointsAfter(_ points: [Point], after: Double) -> [Point] {
     return Array(points[..<endIndex])
 }
 
-/// Discard samples strictly before `before`; keep times unchanged.
+/// Discard samples strictly before `before`, then shift the first retained sample to t=0.
 func cutPointsBefore(_ points: [Point], before: Double) -> [Point] {
     let startIndex = firstPointIndex(atOrAfter: before, in: points)
-    guard startIndex > 0 else {
-        return points
-    }
     guard startIndex < points.count else {
         return []
     }
-    return Array(points[startIndex...])
+    return shiftingFirstPointToZero(Array(points[startIndex...]))
 }
 
-/// Keep samples with `start <= time < end`; times unchanged.
+/// Keep samples with `start <= time < end`, then shift the first retained sample to t=0.
 func trimPoints(_ points: [Point], start: Double, end: Double) -> [Point] {
-    cutPointsAfter(cutPointsBefore(points, before: start), after: end)
+    shiftingFirstPointToZero(pointsInHalfOpenRange(points, start: start, end: end))
+}
+
+private func pointsInHalfOpenRange(_ points: [Point], start: Double, end: Double) -> [Point] {
+    let startIndex = firstPointIndex(atOrAfter: start, in: points)
+    let endIndex = firstPointIndex(atOrAfter: end, in: points)
+    guard startIndex < points.count, startIndex < endIndex else {
+        return []
+    }
+    return Array(points[startIndex ..< endIndex])
+}
+
+private func shiftingFirstPointToZero(_ points: [Point]) -> [Point] {
+    guard let firstTime = points.first?.time else {
+        return points
+    }
+    return points.map { Point(time: $0.time - firstTime, value: $0.value) }
 }
 
 func repeatPoints(_ points: [Point], amount: Double) throws -> [Point] {

--- a/Sources/rigol2spice/xTransforms.swift
+++ b/Sources/rigol2spice/xTransforms.swift
@@ -563,13 +563,43 @@ private func sincResampledValues(_ points: [Point], targetTimes: [Double]) -> [D
 }
 
 /// Extend the capture by `duration` past the last sample, holding `value` (or the last value).
-func padPoints(_ points: [Point], duration: Double, value: Double?) -> [Point] {
+func padDurationPoints(_ points: [Point], duration: Double, value: Double?) -> [Point] {
     guard !points.isEmpty, duration > 0 else {
         return points
     }
     let last = points[points.count - 1]
     var output = points
     output.append(Point(time: last.time + duration, value: value ?? last.value))
+    return output
+}
+
+/// Append exactly `count` samples using the capture interval and holding `value` (or the last value).
+func padPointCount(
+    _ points: [Point],
+    count: Int,
+    value: Double?,
+    sampleInterval providedSampleInterval: Double? = nil,
+) throws -> [Point] {
+    guard !points.isEmpty, count > 0 else {
+        return points
+    }
+    let interval = try resolveSampleInterval(
+        providedSampleInterval,
+        points: points,
+        operation: "PadPoints",
+    )
+    let last = points[points.count - 1]
+    let holdValue = value ?? last.value
+    var output = points
+    output.reserveCapacity(points.count + count)
+    for offset in 1 ... count {
+        output.append(
+            Point(
+                time: last.time + Double(offset) * interval,
+                value: holdValue,
+            ),
+        )
+    }
     return output
 }
 
@@ -662,6 +692,27 @@ func cutPointsBefore(_ points: [Point], before: Double) -> [Point] {
         return []
     }
     return shiftingFirstPointToZero(Array(points[startIndex...]))
+}
+
+/// Remove samples inside the final `duration` of the timestamp range.
+/// A sample exactly on the start boundary is retained.
+func dropLastDurationPoints(_ points: [Point], duration: Double) -> [Point] {
+    guard duration > 0, let lastTime = points.last?.time else {
+        return points
+    }
+    let cutoff = lastTime - duration
+    return points.filter { $0.time <= cutoff }
+}
+
+/// Remove exactly `count` samples from the end of the capture.
+func droppingLastPoints(_ points: [Point], count: Int) -> [Point] {
+    guard count > 0 else {
+        return points
+    }
+    guard count < points.count else {
+        return []
+    }
+    return Array(points.dropLast(count))
 }
 
 /// Keep samples with `start <= time < end`, then shift the first retained sample to t=0.

--- a/Tests/rigol2spiceTests/DropLastTests.swift
+++ b/Tests/rigol2spiceTests/DropLastTests.swift
@@ -1,0 +1,40 @@
+@testable import rigol2spice
+import Testing
+
+struct DropLastTests {
+    @Test
+    func `drop last parses a positive duration`() throws {
+        #expect(try Transformation.parseList("DropLast 5m") == [.dropLast(5e-3)])
+        #expect(throws: (any Error).self) { try Transformation.parseList("DropLast") }
+        #expect(throws: (any Error).self) { try Transformation.parseList("DropLast 0") }
+        #expect(throws: (any Error).self) { try Transformation.parseList("DropLast -1m") }
+    }
+
+    @Test
+    func `drop last points parses a positive integer`() throws {
+        #expect(try Transformation.parseList("DropLastPoints 5") == [.dropLastPoints(5)])
+        #expect(try Transformation.parseList("droplastpoints 2e0") == [.dropLastPoints(2)])
+        #expect(throws: (any Error).self) { try Transformation.parseList("DropLastPoints") }
+        #expect(throws: (any Error).self) { try Transformation.parseList("DropLastPoints 0") }
+        #expect(throws: (any Error).self) { try Transformation.parseList("DropLastPoints 2.5") }
+    }
+
+    @Test
+    func `drop last removes a duration measured back from the final timestamp`() throws {
+        let points = [0.0, 0.5, 2, 3, 5].map { Point(time: $0, value: $0 * 10) }
+        let result = try Transformation.dropLast(2).applying(to: points)
+
+        #expect(result.map(\.time) == [0, 0.5, 2, 3])
+        #expect(result.map(\.value) == [0, 5, 20, 30])
+    }
+
+    @Test
+    func `drop last points removes an exact number from the end`() throws {
+        let points = (0 ... 4).map { Point(time: Double($0), value: Double($0)) }
+        let result = try Transformation.dropLastPoints(2).applying(to: points)
+
+        #expect(result.map(\.time) == [0, 1, 2])
+        #expect(droppingLastPoints(points, count: 5).isEmpty)
+        #expect(droppingLastPoints(points, count: 10).isEmpty)
+    }
+}

--- a/Tests/rigol2spiceTests/OversampleTests.swift
+++ b/Tests/rigol2spiceTests/OversampleTests.swift
@@ -1,0 +1,93 @@
+@testable import rigol2spice
+import Foundation
+import Testing
+
+struct OversampleTests {
+    @Test
+    func `oversample parses an integer factor greater than one`() throws {
+        #expect(try Transformation.parseList("Oversample 5") == [.oversample(5)])
+        #expect(try Transformation.parseList("oversample 2e0") == [.oversample(2)])
+        #expect(throws: (any Error).self) { try Transformation.parseList("Oversample") }
+        #expect(throws: (any Error).self) { try Transformation.parseList("Oversample 1") }
+        #expect(throws: (any Error).self) { try Transformation.parseList("Oversample 2.5") }
+    }
+
+    @Test
+    func `oversample averages aligned points from equal segments`() throws {
+        let values = [
+            1.0, 2, 3, 4, 5,
+            3.0, 4, 5, 6, 7,
+        ]
+        let points = values.enumerated().map { index, value in
+            Point(time: 10 + Double(index) * 0.5, value: value)
+        }
+        let result = try Transformation.oversample(2).applying(
+            to: points,
+            sampleInterval: 0.5,
+        )
+
+        #expect(result.map(\.time) == [0, 0.5, 1, 1.5, 2])
+        #expect(result.map(\.value) == [2, 3, 4, 5, 6])
+    }
+
+    @Test
+    func `oversample reports points and time to remove or add`() throws {
+        let points = (0 ..< 12).map { Point(time: Double($0) * 2e-6, value: Double($0)) }
+
+        do {
+            _ = try oversamplePoints(points, factor: 5, sampleInterval: 2e-6)
+            Issue.record("Expected a non-divisible capture to fail")
+        }
+        catch let error as OversampleError {
+            #expect(error == .pointCountNotDivisible(
+                factor: 5,
+                pointCount: 12,
+                removePoints: 2,
+                addPoints: 3,
+                sampleInterval: 2e-6,
+            ))
+            #expect(error.localizedDescription.contains("Remove 2 sample(s) (4us)"))
+            #expect(error.localizedDescription.contains("add 3 sample(s) (6us)"))
+        }
+    }
+
+    @Test
+    func `oversample rejects factors larger than the capture`() {
+        let short = (0 ..< 4).map { Point(time: Double($0), value: Double($0)) }
+        #expect(throws: OversampleError.factorExceedsPointCount(factor: 5, pointCount: 4)) {
+            try oversamplePoints(short, factor: 5)
+        }
+    }
+
+    @Test
+    func `oversample aligns by sample position without requiring a uniform time grid`() throws {
+        var irregular = (0 ..< 10).map { Point(time: Double($0), value: Double($0)) }
+        irregular[6].time += 0.1
+        let result = try oversamplePoints(irregular, factor: 2)
+
+        #expect(result.count == 5)
+        #expect(result.map(\.value) == [2.5, 3.5, 4.5, 5.5, 6.5])
+    }
+
+    @Test
+    func `oversample accepts floating point noise on a uniform timestamp grid`() throws {
+        let origin = 1e9
+        let nominalInterval = 1e-6
+        let points = (0 ..< 10).map { index in
+            Point(
+                time: origin + Double(index) * nominalInterval,
+                value: Double(index),
+            )
+        }
+        let result = try oversamplePoints(
+            points,
+            factor: 2,
+            sampleInterval: nominalInterval,
+        )
+
+        #expect(result.count == 5)
+        #expect(result[0].time == 0)
+        #expect(abs((result[1].time - result[0].time) - nominalInterval) < 1e-7)
+        #expect(result.map(\.value) == [2.5, 3.5, 4.5, 5.5, 6.5])
+    }
+}

--- a/Tests/rigol2spiceTests/PadPointsTests.swift
+++ b/Tests/rigol2spiceTests/PadPointsTests.swift
@@ -1,0 +1,44 @@
+@testable import rigol2spice
+import Testing
+
+struct PadPointsTests {
+    @Test
+    func `pad points and hold last points parse as the same transformation`() throws {
+        let expected = [Transformation.padPoints(count: 3, value: nil)]
+        #expect(try Transformation.parseList("PadPoints 3") == expected)
+        #expect(try Transformation.parseList("HoldLastPoints 3") == expected)
+        #expect(
+            try Transformation.parseList("PadPoints 2, 0")
+                == [.padPoints(count: 2, value: 0)],
+        )
+        #expect(throws: (any Error).self) { try Transformation.parseList("PadPoints 0") }
+        #expect(throws: (any Error).self) { try Transformation.parseList("PadPoints 2.5") }
+    }
+
+    @Test
+    func `pad points appends an exact count on the sampling grid`() throws {
+        let points = [
+            Point(time: 0, value: 1),
+            Point(time: 0.25, value: 2),
+            Point(time: 0.5, value: 3),
+        ]
+        let result = try Transformation.padPoints(count: 3, value: nil).applying(to: points)
+
+        #expect(result.count == 6)
+        #expect(result.map(\.time) == [0, 0.25, 0.5, 0.75, 1, 1.25])
+        #expect(result.map(\.value) == [1, 2, 3, 3, 3, 3])
+    }
+
+    @Test
+    func `pad points accepts a specified level and sample interval`() throws {
+        let points = [Point(time: 2, value: 4)]
+        let result = try Transformation.padPoints(count: 2, value: -1)
+            .applying(to: points, sampleInterval: 0.5)
+
+        #expect(result == [
+            Point(time: 2, value: 4),
+            Point(time: 2.5, value: -1),
+            Point(time: 3, value: -1),
+        ])
+    }
+}

--- a/Tests/rigol2spiceTests/TCNForecastTests.swift
+++ b/Tests/rigol2spiceTests/TCNForecastTests.swift
@@ -1,0 +1,158 @@
+@testable import rigol2spice
+import Foundation
+import Testing
+
+struct TCNForecastTests {
+    @Test
+    func `tcn appends the requested duration on the sampling grid`() throws {
+        let points = (0 ..< 40).map { index in
+            Point(time: Double(index) * 0.25, value: sin(Double(index) * 0.2))
+        }
+
+        let result = try Transformation.tcn(duration: 1, sampleCount: nil).applying(
+            to: points,
+            sampleInterval: 0.25,
+        )
+
+        #expect(result.count == 44)
+        #expect(result.prefix(points.count).elementsEqual(points))
+        #expect(result.suffix(4).map(\.time) == [10, 10.25, 10.5, 10.75])
+        for point in result.suffix(4) {
+            #expect(point.value.isFinite)
+        }
+    }
+
+    @Test
+    func `tcn appends an exact requested sample count over the duration`() throws {
+        let points = (0 ..< 40).map { index in
+            Point(time: Double(index) * 0.25, value: sin(Double(index) * 0.2))
+        }
+        let result = try Transformation.tcn(duration: 1, sampleCount: 7).applying(
+            to: points,
+            sampleInterval: 0.25,
+        )
+
+        #expect(result.count == 47)
+        #expect(result.last?.time == 10.75)
+    }
+
+    @Test
+    func `tcn continues a constant signal exactly`() throws {
+        let points = (0 ..< 12).map { Point(time: Double($0), value: 3.3) }
+        let result = try tcnForecastPoints(points, duration: 3)
+
+        #expect(result.map(\.value) == Array(repeating: 3.3, count: 15))
+        #expect(result.map(\.time) == Array(0 ... 14).map(Double.init))
+    }
+
+    @Test
+    func `tcn extrapolates a dominant linear trend`() throws {
+        let points = (0 ..< 100).map { index in
+            Point(time: Double(index) * 2e-6, value: 0.25 * Double(index) - 2)
+        }
+        let result = try tcnForecastPoints(points, duration: 1e-3)
+
+        #expect(result.count == 600)
+        #expect(abs(result[100].value - 23) < 1e-10)
+        #expect(abs(result[599].value - 147.75) < 1e-10)
+        #expect(abs(result[599].time - 1.198e-3) < 1e-15)
+    }
+
+    @Test
+    func `tcn learns a clean periodic continuation`() throws {
+        let period = 16
+        let points = (0 ..< 128).map { index in
+            Point(
+                time: Double(index) * 1e-3,
+                value: sin(2 * .pi * Double(index) / Double(period)),
+            )
+        }
+        let result = try tcnForecastPoints(points, duration: 16e-3)
+        let forecast = result.suffix(period)
+
+        for (offset, point) in forecast.enumerated() {
+            let expected = sin(2 * .pi * Double(128 + offset) / Double(period))
+            #expect(abs(point.value - expected) < 0.02)
+        }
+    }
+
+    @Test
+    func `tcn detects a period beyond its local receptive field`() throws {
+        let period = 100
+        let points = (0 ..< 300).map { index in
+            let phase = index % period
+            let value = phase < 25 ? 0.0 : phase < 75 ? 3.0 : 0.0
+            return Point(time: Double(index), value: value)
+        }
+        let result = try tcnForecastPoints(points, duration: Double(period))
+
+        #expect(result.count == 400)
+        for offset in 0 ..< period {
+            #expect(abs(result[300 + offset].value - points[200 + offset].value) < 0.02)
+        }
+    }
+
+    @Test
+    func `tcn forecasts one millisecond of the legacy sample without collapsing to its mean`() throws {
+        let url = try #require(
+            Bundle.module.url(
+                forResource: "Legacy",
+                withExtension: "csv",
+                subdirectory: "SampleFiles",
+            ),
+        )
+        let capture = try LegacyCSVParser().parse(Data(contentsOf: url), channel: "CH1")
+        let forecast = try tcnForecast(
+            capture.points,
+            duration: 1e-3,
+            sampleInterval: capture.sampleInterval,
+        )
+        let result = forecast.points
+
+        try #require(result.count == 1700)
+        let predicted = result[1200 ..< 1700].map(\.value)
+        let previousCycle = capture.points[700 ..< 1200].map(\.value)
+        let meanAbsoluteError = zip(predicted, previousCycle)
+            .reduce(0.0) { $0 + abs($1.0 - $1.1) } / Double(predicted.count)
+
+        #expect(meanAbsoluteError < 0.02)
+        #expect((predicted.min() ?? 1) < 0.1)
+        #expect((predicted.max() ?? 0) > 2.9)
+        #expect(forecast.method == .seasonal(period: 500))
+        #expect(forecast.confidence > 0.9)
+    }
+
+    @Test
+    func `tcn reports low confidence for an unpredictable capture`() throws {
+        var state: UInt64 = 0x1234_5678
+        let points = (0 ..< 256).map { index in
+            state = state &* 6_364_136_223_846_793_005 &+ 1
+            let value = Double(state >> 11) / Double(UInt64.max >> 11) * 2 - 1
+            return Point(time: Double(index), value: value)
+        }
+        let forecast = try tcnForecast(points, duration: 64)
+
+        #expect(forecast.points.count == 320)
+        #expect(forecast.confidence < 0.25)
+        #expect(forecast.method == .mean || forecast.method == .holdLast)
+    }
+
+    @Test
+    func `tcn rejects short non finite and irregular inputs`() {
+        #expect(throws: TCNForecastError.notEnoughSamples(actual: 7, minimum: 8)) {
+            try tcnForecastPoints((0 ..< 7).map { Point(time: Double($0), value: 0) }, duration: 1)
+        }
+
+        var nonFinite = (0 ..< 8).map { Point(time: Double($0), value: 0) }
+        nonFinite[4].value = .nan
+        #expect(throws: TCNForecastError.nonFiniteSample(index: 4)) {
+            try tcnForecastPoints(nonFinite, duration: 1)
+        }
+
+        var irregular = (0 ..< 8).map { Point(time: Double($0), value: Double($0)) }
+        irregular[5].time += 0.1
+        #expect(throws: TCNForecastError.nonUniformSampling(index: 5)) {
+            try tcnForecastPoints(irregular, duration: 1)
+        }
+    }
+}

--- a/Tests/rigol2spiceTests/TCNForecastTests.swift
+++ b/Tests/rigol2spiceTests/TCNForecastTests.swift
@@ -138,7 +138,7 @@ struct TCNForecastTests {
     }
 
     @Test
-    func `tcn rejects short non finite and irregular inputs`() {
+    func `forecast rejects short and non finite inputs but accepts irregular timestamps`() throws {
         #expect(throws: TCNForecastError.notEnoughSamples(actual: 7, minimum: 8)) {
             try tcnForecastPoints((0 ..< 7).map { Point(time: Double($0), value: 0) }, duration: 1)
         }
@@ -151,8 +151,8 @@ struct TCNForecastTests {
 
         var irregular = (0 ..< 8).map { Point(time: Double($0), value: Double($0)) }
         irregular[5].time += 0.1
-        #expect(throws: TCNForecastError.nonUniformSampling(index: 5)) {
-            try tcnForecastPoints(irregular, duration: 1)
-        }
+        let result = try tcnForecastPoints(irregular, duration: 1)
+        #expect(result.count == 9)
+        #expect(result.last?.time == 8)
     }
 }

--- a/Tests/rigol2spiceTests/rigol2spiceTests.swift
+++ b/Tests/rigol2spiceTests/rigol2spiceTests.swift
@@ -87,6 +87,21 @@ struct Rigol2spiceTests {
     }
 
     @Test
+    func `forecast accepts a positive duration and optional sample count`() throws {
+        #expect(try Transformation.parseList("Forecast 5m") == [.tcn(duration: 5e-3, sampleCount: nil)])
+        #expect(try Transformation.parseList("forecast 2e-6") == [.tcn(duration: 2e-6, sampleCount: nil)])
+        #expect(try Transformation.parseList("Forecast 2m, 2k") == [.tcn(duration: 2e-3, sampleCount: 2000)])
+        #expect(try Transformation.parseList("Forecast 1m, 500") == [.tcn(duration: 1e-3, sampleCount: 500)])
+        #expect(try Transformation.parseList("Forecast 1m") == [.tcn(duration: 1e-3, sampleCount: nil)])
+        #expect(throws: (any Error).self) { try Transformation.parseList("Predict 1m") }
+        #expect(throws: (any Error).self) { try Transformation.parseList("TCN 1m") }
+        #expect(throws: (any Error).self) { try Transformation.parseList("Forecast") }
+        #expect(throws: (any Error).self) { try Transformation.parseList("Forecast 0") }
+        #expect(throws: (any Error).self) { try Transformation.parseList("Forecast -1m") }
+        #expect(throws: (any Error).self) { try Transformation.parseList("Forecast 1m, 2.5") }
+    }
+
+    @Test
     func `rejects legacy negative prefix`() {
         do {
             _ = try Transformation.parseList("Offset N1.2")
@@ -561,18 +576,18 @@ struct Rigol2spiceTests {
     }
 
     @Test
-    func `cut before discards samples before the timestamp`() throws {
+    func `cut before discards samples and shifts the first retained sample to zero`() throws {
         #expect(try Transformation.parseList("CutBefore 2") == [.cutBefore(2)])
 
         let points = (0 ... 4).map { Point(time: Double($0), value: Double($0)) }
         let result = try Transformation.cutBefore(2).applying(to: points)
 
-        #expect(result.map(\.time) == [2, 3, 4])
+        #expect(result.map(\.time) == [0, 1, 2])
         #expect(result.map(\.value) == [2, 3, 4])
     }
 
     @Test
-    func `trim keeps samples inside the half open window`() throws {
+    func `trim keeps the half open window and shifts its first sample to zero`() throws {
         #expect(try Transformation.parseList("Trim 1m, 10m") == [.trim(start: 1e-3, end: 10e-3)])
         #expect(throws: (any Error).self) {
             try Transformation.parseList("Trim 2, 1")
@@ -581,7 +596,8 @@ struct Rigol2spiceTests {
         let points = (0 ... 5).map { Point(time: Double($0), value: Double($0)) }
         let result = try Transformation.trim(start: 2, end: 5).applying(to: points)
 
-        #expect(result.map(\.time) == [2, 3, 4])
+        #expect(result.map(\.time) == [0, 1, 2])
+        #expect(result.map(\.value) == [2, 3, 4])
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add temporal convolutional network forecasting for waveform processing
- Introduce oversampling and point-padding transformations
- Integrate the new processing flow into the application
- Expand README documentation and regression coverage

## Testing

- Added unit tests for TCN forecasting, oversampling, point padding, and dropping trailing points
- Not run (not requested)